### PR TITLE
[BD-05] [BB-2963] Improve Instructor dashboard

### DIFF
--- a/src/components/value-or-loading/ValueOrLoading.jsx
+++ b/src/components/value-or-loading/ValueOrLoading.jsx
@@ -11,7 +11,7 @@ function LoadingOrValue({ value }) {
 }
 
 LoadingOrValue.propTypes = {
-  value: PropType.oneOfType([PropType.element, PropType.number]),
+  value: PropType.node,
 };
 
 LoadingOrValue.defaultProps = {

--- a/src/components/value-or-loading/ValueOrLoading.jsx
+++ b/src/components/value-or-loading/ValueOrLoading.jsx
@@ -11,7 +11,7 @@ function LoadingOrValue({ value }) {
 }
 
 LoadingOrValue.propTypes = {
-  value: PropType.element,
+  value: PropType.oneOfType([PropType.element, PropType.number]),
 };
 
 LoadingOrValue.defaultProps = {

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -31,3 +31,15 @@ export const oraDataShape = PropTypes.objectOf(PropTypes.shape({
   done: PropTypes.number,
   status: PropTypes.string,
 }));
+
+export const oraSummaryDataShape = PropTypes.objectOf(PropTypes.shape({
+  units: PropTypes.number,
+  assessments: PropTypes.number,
+  total: PropTypes.number,
+  training: PropTypes.number,
+  peer: PropTypes.number,
+  self: PropTypes.number,
+  waiting: PropTypes.number,
+  staff: PropTypes.number,
+  done: PropTypes.number,
+}));

--- a/src/ora-dashboard/OraDashboard.jsx
+++ b/src/ora-dashboard/OraDashboard.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import SummaryTable from './summary-table/SummaryTable';
 import DataTable from './data-table/DataTable';
-import { oraDataShape } from '../data/constants';
+import { oraDataShape, oraSummaryDataShape } from '../data/constants';
 
-function OraDashboard({ data }) {
+function OraDashboard({ data, summary }) {
   return (
     <main>
       <div className="container-fluid">
         <h1>Open Responses</h1>
-        <SummaryTable />
+        <SummaryTable data={summary} />
         <DataTable data={data} />
       </div>
     </main>
@@ -16,11 +16,8 @@ function OraDashboard({ data }) {
 }
 
 OraDashboard.propTypes = {
-  data: oraDataShape,
-};
-
-OraDashboard.defaultProps = {
-  data: {},
+  data: oraDataShape.isRequired,
+  summary: oraSummaryDataShape.isRequired,
 };
 
 export default OraDashboard;

--- a/src/ora-dashboard/OraDashboard.jsx
+++ b/src/ora-dashboard/OraDashboard.jsx
@@ -1,15 +1,26 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
+import { Spinner } from '@edx/paragon';
 import SummaryTable from './summary-table/SummaryTable';
 import DataTable from './data-table/DataTable';
-import { oraDataShape, oraSummaryDataShape } from '../data/constants';
+import { oraDataShape, oraSummaryDataShape, RequestStatus } from '../data/constants';
+import { loadingStatus } from './data/selectors';
 
 function OraDashboard({ data, summary }) {
+  const status = useSelector(loadingStatus);
+
   return (
     <main>
       <div className="container-fluid">
         <h1>Open Responses</h1>
-        <SummaryTable data={summary} />
-        <DataTable data={data} />
+        {status === RequestStatus.IN_PROGRESS && <Spinner animation="border" variant="primary" />}
+        {status === RequestStatus.SUCCESSFUL && (
+          <div>
+            <SummaryTable data={summary} />
+            <DataTable data={data} />
+          </div>
+        )}
+
       </div>
     </main>
   );

--- a/src/ora-dashboard/OraDashboard.jsx
+++ b/src/ora-dashboard/OraDashboard.jsx
@@ -1,3 +1,4 @@
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { Spinner } from '@edx/paragon';
@@ -5,20 +6,21 @@ import SummaryTable from './summary-table/SummaryTable';
 import DataTable from './data-table/DataTable';
 import { oraDataShape, oraSummaryDataShape, RequestStatus } from '../data/constants';
 import { loadingStatus } from './data/selectors';
+import messages from './messages';
 
-function OraDashboard({ data, summary }) {
+function OraDashboard({ intl, data, summary }) {
   const status = useSelector(loadingStatus);
 
   return (
     <main>
       <div className="container-fluid">
-        <h1>Open Responses</h1>
+        <h1>{intl.formatMessage(messages.section_heading)}</h1>
         {status === RequestStatus.IN_PROGRESS && <Spinner animation="border" variant="primary" />}
         {status === RequestStatus.SUCCESSFUL && (
-          <div>
+          <>
             <SummaryTable data={summary} />
             <DataTable data={data} />
-          </div>
+          </>
         )}
 
       </div>
@@ -27,8 +29,9 @@ function OraDashboard({ data, summary }) {
 }
 
 OraDashboard.propTypes = {
+  intl: intlShape.isRequired,
   data: oraDataShape.isRequired,
   summary: oraSummaryDataShape.isRequired,
 };
 
-export default OraDashboard;
+export default injectIntl(OraDashboard);

--- a/src/ora-dashboard/OraDashboardContainer.jsx
+++ b/src/ora-dashboard/OraDashboardContainer.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router';
-import { selectOraBlocks } from './data/selectors';
+import { selectOraBlocks, selectSummary } from './data/selectors';
 import { fetchOraBlocks } from './data/thunks';
 import OraDashboard from './OraDashboard';
 
@@ -9,12 +9,14 @@ export default function OraDashboardContainer() {
   const { courseId } = useParams();
   const dispatch = useDispatch();
   const oraBlocks = useSelector(selectOraBlocks);
+  const summary = useSelector(selectSummary);
+
   useEffect(() => {
     // The courseId from the URL is the course we WANT to load.
     dispatch(fetchOraBlocks(courseId));
   }, [courseId]);
 
   return (
-    <OraDashboard data={oraBlocks} />
+    <OraDashboard data={oraBlocks} summary={summary} />
   );
 }

--- a/src/ora-dashboard/data-table/DataTable.jsx
+++ b/src/ora-dashboard/data-table/DataTable.jsx
@@ -11,8 +11,14 @@ function DataTable({ intl, data }) {
   const { courseId } = useParams();
   const dispatch = useDispatch();
   useEffect(() => {
-    Object.keys(data).map((blockId) => data[blockId].status || dispatch(fetchOraReports(courseId, blockId)));
+    if (Object.keys(data).length > 0) {
+      const blockId = Object.keys(data)[0];
+      if (!data[blockId].status) {
+        dispatch(fetchOraReports(courseId, blockId));
+      }
+    }
   }, [courseId, data]);
+
   return (
     <table className="table">
       <thead>

--- a/src/ora-dashboard/data-table/DataTable.jsx
+++ b/src/ora-dashboard/data-table/DataTable.jsx
@@ -1,11 +1,29 @@
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import React, { useEffect } from 'react';
+import { Table } from '@edx/paragon';
 import { useDispatch } from 'react-redux';
 import { useParams } from 'react-router';
-import LoadingOrValue from '../../components/value-or-loading/ValueOrLoading';
 import messages from './messages';
 import { fetchOraReports } from '../data/thunks';
 import { oraDataShape } from '../../data/constants';
+
+/**
+ * Sort implementation for Paragon Table
+ * @param {any} firstElement
+ * @param {any} secondElement
+ * @param {string} key
+ * @param {string} direction
+ */
+const sort = function sort(firstElement, secondElement, key, direction) {
+  const directionIsAsc = direction === 'asc';
+
+  if (firstElement[key] > secondElement[key]) {
+    return directionIsAsc ? 1 : -1;
+  } if (firstElement[key] < secondElement[key]) {
+    return directionIsAsc ? -1 : 1;
+  }
+  return 0;
+};
 
 function DataTable({ intl, data }) {
   const { courseId } = useParams();
@@ -19,55 +37,70 @@ function DataTable({ intl, data }) {
     }
   }, [courseId, data]);
 
+  // create a copy of data for sortable Table
+  const sortableData = Object.values(data).slice();
+
+  // define Table columns
+  const columns = [
+    {
+      label: intl.formatMessage(messages.unit_name),
+      key: 'vertical',
+      columnSortable: true,
+    },
+    {
+      label: intl.formatMessage(messages.assessment),
+      key: 'name',
+      columnSortable: true,
+    },
+    {
+      label: intl.formatMessage(messages.total_responses),
+      key: 'total',
+      columnSortable: true,
+    },
+    {
+      label: intl.formatMessage(messages.training),
+      key: 'training',
+      columnSortable: true,
+    },
+    {
+      label: intl.formatMessage(messages.peer),
+      key: 'peer',
+      columnSortable: true,
+    },
+    {
+      label: intl.formatMessage(messages.self),
+      key: 'self',
+      columnSortable: true,
+    },
+    {
+      label: intl.formatMessage(messages.waiting),
+      key: 'waiting',
+      columnSortable: true,
+    },
+    {
+      label: intl.formatMessage(messages.staff),
+      key: 'staff',
+      columnSortable: true,
+    },
+    {
+      label: intl.formatMessage(messages.final_grade_received),
+      key: 'done',
+      columnSortable: true,
+    },
+  ];
+
   return (
-    <table className="table">
-      <thead>
-        <tr>
-          <th>
-            {intl.formatMessage(messages.unit_name)}
-          </th>
-          <th>
-            {intl.formatMessage(messages.assessment)}
-          </th>
-          <th>
-            {intl.formatMessage(messages.total_responses)}
-          </th>
-          <th>
-            {intl.formatMessage(messages.training)}
-          </th>
-          <th>
-            {intl.formatMessage(messages.peer)}
-          </th>
-          <th>
-            {intl.formatMessage(messages.self)}
-          </th>
-          <th>
-            {intl.formatMessage(messages.waiting)}
-          </th>
-          <th>
-            {intl.formatMessage(messages.staff)}
-          </th>
-          <th>
-            {intl.formatMessage(messages.final_grade_received)}
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        {Object.values(data).map(((block) => (
-          <tr key={block.id}>
-            <td>{block.vertical}</td>
-            <td>{block.name}</td>
-            <td><LoadingOrValue value={block.total} /></td>
-            <td><LoadingOrValue value={block.training} /></td>
-            <td><LoadingOrValue value={block.peer} /></td>
-            <td><LoadingOrValue value={block.self} /></td>
-            <td><LoadingOrValue value={block.waiting} /></td>
-            <td><LoadingOrValue value={block.staff} /></td>
-            <td><LoadingOrValue value={block.done} /></td>
-          </tr>
-        )))}
-      </tbody>
-    </table>
+    <Table
+      data={sortableData}
+      columns={columns.map(column => ({
+        ...column,
+        onSort(direction) {
+          console.log('Sort in direction ', direction, column);
+          sortableData.sort((firstElement, secondElement) => sort(firstElement, secondElement, column.key, direction));
+        },
+      }))}
+      tableSortable
+    />
   );
 }
 DataTable.propTypes = {

--- a/src/ora-dashboard/data-table/DataTable.jsx
+++ b/src/ora-dashboard/data-table/DataTable.jsx
@@ -15,7 +15,7 @@ import EmbedORAModal from '../embed-ora-modal/EmbedORAModal';
  * @param {string} key
  * @param {string} direction
  */
-const sort = function sort(firstElement, secondElement, key, direction) {
+function sort(firstElement, secondElement, key, direction) {
   const directionIsAsc = direction === 'asc';
 
   if (firstElement[key] > secondElement[key]) {
@@ -24,7 +24,7 @@ const sort = function sort(firstElement, secondElement, key, direction) {
     return directionIsAsc ? -1 : 1;
   }
   return 0;
-};
+}
 
 function DataTable({ intl, data }) {
   const { courseId } = useParams();
@@ -39,7 +39,10 @@ function DataTable({ intl, data }) {
   }, [courseId, data]);
 
   // create a copy of data for sortable Table
-  const sortableData = Object.values(data).slice().map(item => ({ ...item, actions: (<EmbedORAModal usageKey={item.id} title={item.name} buttonText="Manage" />) }));
+  const sortableData = Object.values(data).slice().map(item => {
+    const action = item.staff > 0 ? (<EmbedORAModal usageKey={item.id} title={item.name} buttonText="Manage" />) : <></>;
+    return { ...item, actions: action };
+  });
 
   // define Table columns
   const columns = [
@@ -94,8 +97,6 @@ function DataTable({ intl, data }) {
     },
   ];
 
-  console.log(sortableData.map(i => i.id));
-
   return (
     <div>
       <Table
@@ -103,7 +104,6 @@ function DataTable({ intl, data }) {
         columns={columns.map(column => ({
           ...column,
           onSort(direction) {
-            console.log('Sort in direction ', direction, column);
             sortableData.sort(
               (firstElement, secondElement) => sort(firstElement, secondElement, column.key, direction),
             );

--- a/src/ora-dashboard/data-table/DataTable.jsx
+++ b/src/ora-dashboard/data-table/DataTable.jsx
@@ -40,7 +40,7 @@ function DataTable({ intl, data }) {
 
   // create a copy of data for sortable Table
   const sortableData = Object.values(data).slice().map(item => {
-    const action = item.staff > 0 ? (<EmbedORAModal usageKey={item.id} title={item.name} buttonText="Manage" />) : <></>;
+    const action = <EmbedORAModal usageKey={item.id} title={item.name} buttonText="Manage" />;
     return { ...item, actions: action };
   });
 

--- a/src/ora-dashboard/data-table/DataTable.jsx
+++ b/src/ora-dashboard/data-table/DataTable.jsx
@@ -6,6 +6,7 @@ import { useParams } from 'react-router';
 import messages from './messages';
 import { fetchOraReports } from '../data/thunks';
 import { oraDataShape } from '../../data/constants';
+import EmbedORAModal from '../embed-ora-modal/EmbedORAModal';
 
 /**
  * Sort implementation for Paragon Table
@@ -38,7 +39,7 @@ function DataTable({ intl, data }) {
   }, [courseId, data]);
 
   // create a copy of data for sortable Table
-  const sortableData = Object.values(data).slice();
+  const sortableData = Object.values(data).slice().map(item => ({ ...item, actions: (<EmbedORAModal usageKey={item.id} title={item.name} buttonText="Manage" />) }));
 
   // define Table columns
   const columns = [
@@ -87,20 +88,31 @@ function DataTable({ intl, data }) {
       key: 'done',
       columnSortable: true,
     },
+    {
+      label: '',
+      key: 'actions',
+    },
   ];
 
+  console.log(sortableData.map(i => i.id));
+
   return (
-    <Table
-      data={sortableData}
-      columns={columns.map(column => ({
-        ...column,
-        onSort(direction) {
-          console.log('Sort in direction ', direction, column);
-          sortableData.sort((firstElement, secondElement) => sort(firstElement, secondElement, column.key, direction));
-        },
-      }))}
-      tableSortable
-    />
+    <div>
+      <Table
+        data={sortableData}
+        columns={columns.map(column => ({
+          ...column,
+          onSort(direction) {
+            console.log('Sort in direction ', direction, column);
+            sortableData.sort(
+              (firstElement, secondElement) => sort(firstElement, secondElement, column.key, direction),
+            );
+          },
+        }))}
+        tableSortable
+      />
+      {/* {iframes} */}
+    </div>
   );
 }
 DataTable.propTypes = {

--- a/src/ora-dashboard/data/selectors.js
+++ b/src/ora-dashboard/data/selectors.js
@@ -1,4 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 export const selectOraBlocks = state => state.blocks;
 
+export const selectSummary = state => state.summary;
+
 export const loadingStatus = state => state.status;

--- a/src/ora-dashboard/data/slices.js
+++ b/src/ora-dashboard/data/slices.js
@@ -64,23 +64,21 @@ function oraBlockStatisticsFromPayload(blockIds, payload) {
 function prepareStatisticsSummary(data) {
   const dataKeys = Object.keys(data);
   const dataItemArr = dataKeys.map((key) => data[key]);
-  const sumByKey = (key) => dataItemArr.map((item) => item[key]).reduce((result, val) => result + val, 0);
+
+  const sumByKey = (key) => dataItemArr
+    .map((item) => (item[key] ? item[key] : 0))
+    .reduce((result, val) => result + val, 0);
+
   const fields = ['total', 'training', 'peer', 'self', 'waiting', 'staff', 'done'];
   const summaryData = {
     units: dataKeys.length,
     assessments: dataKeys.length,
   };
 
-  if (dataKeys.length > 0 && data[dataKeys[0]].status === RequestStatus.SUCCESSFUL) {
-    fields.forEach(field => {
-      summaryData[field] = sumByKey(field);
-    });
-  } else if (dataKeys.length === 0) {
-    // there is no ORA block in the course.
-    fields.forEach(field => {
-      summaryData[field] = 0;
-    });
-  }
+  fields.forEach(field => {
+    summaryData[field] = sumByKey(field);
+  });
+
   return summaryData;
 }
 

--- a/src/ora-dashboard/data/slices.js
+++ b/src/ora-dashboard/data/slices.js
@@ -33,11 +33,63 @@ function oraBlocksFromResponse(response) {
   return oraBlocks;
 }
 
+/**
+ * Given a get_ora2_responses API response, set statistics for each ORA Block.
+ * Also assign default value if there is no statistics for any block.
+ * @param {array} blockIds - list of blockIdx in current course
+ * @param {object} payload - get_ora2_responses api response
+ */
+function oraBlockStatisticsFromPayload(blockIds, payload) {
+  const blocks = {};
+  const defaultValues = {
+    status: RequestStatus.SUCCESSFUL,
+    total: 0,
+    training: 0,
+    peer: 0,
+    self: 0,
+    waiting: 0,
+    staff: 0,
+    done: 0,
+  };
+  blockIds.forEach(blockId => {
+    blocks[blockId] = { ...defaultValues, ...payload[blockId] };
+  });
+  return blocks;
+}
+
+/**
+ * Given current state.oraBlocks object, prepares summary.
+ * @param {object} data - state.oraBlocks
+ */
+function prepareStatisticsSummary(data) {
+  const dataKeys = Object.keys(data);
+  const dataItemArr = dataKeys.map((key) => data[key]);
+  const sumByKey = (key) => dataItemArr.map((item) => item[key]).reduce((result, val) => result + val, 0);
+  const fields = ['total', 'training', 'peer', 'self', 'waiting', 'staff', 'done'];
+  const summaryData = {
+    units: dataKeys.length,
+    assessments: dataKeys.length,
+  };
+
+  if (dataKeys.length > 0 && data[dataKeys[0]].status === RequestStatus.SUCCESSFUL) {
+    fields.forEach(field => {
+      summaryData[field] = sumByKey(field);
+    });
+  } else if (dataKeys.length === 0) {
+    // there is no ORA block in the course.
+    fields.forEach(field => {
+      summaryData[field] = 0;
+    });
+  }
+  return summaryData;
+}
+
 const oraSlice = createSlice({
   name: 'ora',
   initialState: {
     status: RequestStatus.IN_PROGRESS,
     blocks: {},
+    summary: {},
   },
   reducers: {
     fetchOraBlocksRequest: (state) => {
@@ -57,10 +109,12 @@ const oraSlice = createSlice({
       state.blocks[payload.blockId].status = RequestStatus.IN_PROGRESS;
     },
     fetchOraReportSuccess: (state, { payload }) => {
-      Object.keys(payload).forEach((blockId) => {
-        state.blocks[blockId].status = RequestStatus.SUCCESSFUL;
-        Object.assign(state.blocks[blockId], payload[blockId]);
+      const statistics = oraBlockStatisticsFromPayload(Object.keys(state.blocks), payload);
+      Object.keys(state.blocks).forEach(blockId => {
+        state.blocks[blockId] = { ...state.blocks[blockId], ...statistics[blockId] };
       });
+      // as statistics updated, update summary too.
+      state.summary = prepareStatisticsSummary(state.blocks);
     },
     fetchOraReportFailed: (state, { payload }) => {
       state.blocks[payload.blockId].status = RequestStatus.FAILED;

--- a/src/ora-dashboard/embed-ora-modal/EmbedORAModal.jsx
+++ b/src/ora-dashboard/embed-ora-modal/EmbedORAModal.jsx
@@ -1,0 +1,37 @@
+import { Button, Modal } from '@edx/paragon';
+import { getConfig } from '@edx/frontend-platform';
+import React, { useState } from 'react';
+
+import PropTypes from 'prop-types';
+
+const { LMS_BASE_URL } = getConfig();
+
+function EmbedORAModal({ usageKey, title, buttonText }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="embed-ora-modal">
+      <Modal
+        open={open}
+        dialogClassName="modal-lg"
+        title={title}
+        renderDefaultCloseButton={false}
+        onClose={() => setOpen(false)}
+        body={(
+          <div className="embed-responsive embed-responsive-16by9">
+            <iframe title={title} className="embed-responsive-item ora-iframe" src={`${LMS_BASE_URL}/xblock/${usageKey}`} />
+          </div>
+        )}
+      />
+      <Button variant="light" onClick={() => setOpen(true)}>{buttonText}</Button>
+    </div>
+  );
+}
+
+EmbedORAModal.propTypes = {
+  usageKey: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  buttonText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+};
+
+export default EmbedORAModal;

--- a/src/ora-dashboard/messages.js
+++ b/src/ora-dashboard/messages.js
@@ -1,0 +1,11 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  section_heading: {
+    id: 'ora.dashboard.heading',
+    defaultMessage: 'Open Responses',
+    description: 'Section heading',
+  },
+});
+
+export default messages;

--- a/src/ora-dashboard/summary-table/SummaryTable.jsx
+++ b/src/ora-dashboard/summary-table/SummaryTable.jsx
@@ -1,8 +1,10 @@
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import React from 'react';
 import messages from './messages';
+import LoadingOrValue from '../../components/value-or-loading/ValueOrLoading';
+import { oraSummaryDataShape } from '../../data/constants';
 
-function SummaryTable({ intl }) {
+function SummaryTable({ intl, data }) {
   return (
     <table className="table">
       <thead>
@@ -36,11 +38,25 @@ function SummaryTable({ intl }) {
           </th>
         </tr>
       </thead>
+      <tbody>
+        <tr>
+          <td><LoadingOrValue value={data.units} /></td>
+          <td><LoadingOrValue value={data.assessments} /></td>
+          <td><LoadingOrValue value={data.total} /></td>
+          <td><LoadingOrValue value={data.training} /></td>
+          <td><LoadingOrValue value={data.peer} /></td>
+          <td><LoadingOrValue value={data.self} /></td>
+          <td><LoadingOrValue value={data.waiting} /></td>
+          <td><LoadingOrValue value={data.staff} /></td>
+          <td><LoadingOrValue value={data.done} /></td>
+        </tr>
+      </tbody>
     </table>
   );
 }
 SummaryTable.propTypes = {
   intl: intlShape.isRequired,
+  data: oraSummaryDataShape.isRequired,
 };
 
 export default injectIntl(SummaryTable);

--- a/src/ora-dashboard/summary-table/SummaryTable.jsx
+++ b/src/ora-dashboard/summary-table/SummaryTable.jsx
@@ -1,57 +1,53 @@
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import React from 'react';
+import { Table } from '@edx/paragon';
 import messages from './messages';
-import LoadingOrValue from '../../components/value-or-loading/ValueOrLoading';
 import { oraSummaryDataShape } from '../../data/constants';
 
 function SummaryTable({ intl, data }) {
+  const columns = [
+    {
+      label: intl.formatMessage(messages.units),
+      key: 'units',
+    },
+    {
+      label: intl.formatMessage(messages.assessments),
+      key: 'assessments',
+    },
+    {
+      label: intl.formatMessage(messages.total_responses),
+      key: 'total',
+    },
+    {
+      label: intl.formatMessage(messages.training),
+      key: 'training',
+    },
+    {
+      label: intl.formatMessage(messages.peer),
+      key: 'peer',
+    },
+    {
+      label: intl.formatMessage(messages.self),
+      key: 'self',
+    },
+    {
+      label: intl.formatMessage(messages.waiting),
+      key: 'waiting',
+    },
+    {
+      label: intl.formatMessage(messages.staff),
+      key: 'staff',
+    },
+    {
+      label: intl.formatMessage(messages.final_grade_received),
+      key: 'done',
+    },
+  ];
   return (
-    <table className="table">
-      <thead>
-        <tr>
-          <th>
-            {intl.formatMessage(messages.units)}
-          </th>
-          <th>
-            {intl.formatMessage(messages.assessments)}
-          </th>
-          <th>
-            {intl.formatMessage(messages.total_responses)}
-          </th>
-          <th>
-            {intl.formatMessage(messages.training)}
-          </th>
-          <th>
-            {intl.formatMessage(messages.peer)}
-          </th>
-          <th>
-            {intl.formatMessage(messages.self)}
-          </th>
-          <th>
-            {intl.formatMessage(messages.waiting)}
-          </th>
-          <th>
-            {intl.formatMessage(messages.staff)}
-          </th>
-          <th>
-            {intl.formatMessage(messages.final_grade_received)}
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><LoadingOrValue value={data.units} /></td>
-          <td><LoadingOrValue value={data.assessments} /></td>
-          <td><LoadingOrValue value={data.total} /></td>
-          <td><LoadingOrValue value={data.training} /></td>
-          <td><LoadingOrValue value={data.peer} /></td>
-          <td><LoadingOrValue value={data.self} /></td>
-          <td><LoadingOrValue value={data.waiting} /></td>
-          <td><LoadingOrValue value={data.staff} /></td>
-          <td><LoadingOrValue value={data.done} /></td>
-        </tr>
-      </tbody>
-    </table>
+    <Table
+      data={[data]}
+      columns={columns}
+    />
   );
 }
 SummaryTable.propTypes = {


### PR DESCRIPTION
This PR introduces a couple of improvements for the instructor dashboard in MFE -
- Uses ``edx/paragon`` components to display data and loading spinner
- Summary table values are generated
- Table can be sorted by column value
- ORA block embedded in an iframe inside a Modal.

**JIRA tickets**: 
- https://tasks.opencraft.com/browse/BB-2963

~~**Discussions**:~~

**Dependencies**: None

**Screenshots**: 
![Screenshot from 2020-11-23 23-55-58](https://user-images.githubusercontent.com/1010244/99997717-c4f4b980-2de7-11eb-978e-03cf06022d1c.png)

Embed Staff Grading -
![Screenshot from 2020-11-23 23-56-20](https://user-images.githubusercontent.com/1010244/99997728-c7571380-2de7-11eb-8b68-2e0e313359ad.png)


~~**Sandbox URL**:~~

**Merge deadline**: None

**Testing instructions**:

1. Run local devstack
2. Clone this repo and checkout this PR
3. Add ORA blocks in local devstack
4. Go to ``http://localhost:2003/<course_key>``
5. Statistics for ORA blocks will be shown.
6. Clicking on the Manage button should show embedded xblock and staff grading can be done from there.

**Author notes and concerns**:

1. This PR uses ``edx/paragon`` ``Table`` component which is not stable yet. https://edx.github.io/paragon/components/table
2. I couldn't find any API that will only embed staff grading as those templates have some dependency with JS. Rather I've embedded full xblock from LMS. But that might mean a possible issue with ``X-frame-options`` due to cross-site iframe embedding in production.

**Reviewers**
- [ ] @xitij2000 
- [ ] edX reviewer[s] TBD